### PR TITLE
Issue #8, add target specification

### DIFF
--- a/WhiskSwiftTools.xcodeproj/project.pbxproj
+++ b/WhiskSwiftTools.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D676B4B91D64AAA400A29AE5 /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = D676B4A61D64AAA400A29AE5 /* zip.c */; };
 		D676B4BA1D64AAA400A29AE5 /* SSZipArchive+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = D676B4A81D64AAA400A29AE5 /* SSZipArchive+Swift.swift */; };
 		D676B4BB1D64AAA400A29AE5 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = D676B4AA1D64AAA400A29AE5 /* SSZipArchive.m */; };
+		D699E7BD1D79E9A40081C461 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D699E7BC1D79E9A40081C461 /* PBXProject.swift */; };
 		D6BC1BF61D4017BE00C2334C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BC1BF51D4017BE00C2334C /* main.swift */; };
 		D6BC1BFD1D4017FD00C2334C /* WhiskInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BC1BFC1D4017FD00C2334C /* WhiskInstaller.swift */; };
 		D6BC1BFF1D40180A00C2334C /* ConsoleIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BC1BFE1D40180A00C2334C /* ConsoleIO.swift */; };
@@ -84,6 +85,7 @@
 		D676B4AA1D64AAA400A29AE5 /* SSZipArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSZipArchive.m; sourceTree = "<group>"; };
 		D676B4AB1D64AAA400A29AE5 /* SSZipCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSZipCommon.h; sourceTree = "<group>"; };
 		D676B4AC1D64AAA400A29AE5 /* ZipArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZipArchive.h; sourceTree = "<group>"; };
+		D699E7BC1D79E9A40081C461 /* PBXProject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PBXProject.swift; sourceTree = "<group>"; };
 		D6BC1BF21D4017BE00C2334C /* wsktool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wsktool; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6BC1BF51D4017BE00C2334C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D6BC1BFC1D4017FD00C2334C /* WhiskInstaller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhiskInstaller.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 				D6BC1C2C1D4119FB00C2334C /* SequenceCode.swift */,
 				D6BC1C2D1D4119FB00C2334C /* WhiskAPI.swift */,
 				D6BC1C341D41391D00C2334C /* WhiskTokenizer.swift */,
+				D699E7BC1D79E9A40081C461 /* PBXProject.swift */,
 			);
 			name = WhiskTool;
 			path = WhiskSwiftTools;
@@ -302,6 +305,7 @@
 				D676B4B91D64AAA400A29AE5 /* zip.c in Sources */,
 				D6BC1C2E1D4119FB00C2334C /* Git.swift in Sources */,
 				D6BC1C301D4119FB00C2334C /* ProjectManager.swift in Sources */,
+				D699E7BD1D79E9A40081C461 /* PBXProject.swift in Sources */,
 				D676B4AE1D64AAA400A29AE5 /* aeskey.c in Sources */,
 				D676B4B81D64AAA400A29AE5 /* unzip.c in Sources */,
 				D676B4B31D64AAA400A29AE5 /* prng.c in Sources */,

--- a/WhiskSwiftTools/ConsoleIO.swift
+++ b/WhiskSwiftTools/ConsoleIO.swift
@@ -16,8 +16,11 @@
 
 import Foundation
 
+let version = "0.1.0"
+
 enum OptionType: String {
     case Build = "build"
+    case Version = "version"
     case Help = "help"
     case Delete = "delete"
     case Undefined
@@ -28,6 +31,10 @@ enum OptionType: String {
             self = .Build
         case "uninstall":
             self = .Delete
+        case "version":
+            self = .Version
+        case "v":
+            self = .Version
         case "help":
             self = .Help
         case "h":
@@ -56,6 +63,10 @@ class ConsoleIO {
         print ("\(executableName) uninstall <project directory>")
         
         print ("Type \(executableName) -h or --help to show usage information")
+    }
+    
+    class func printVersion() {
+        print("\(version)")
     }
     
     func getOption(_ option: String) -> (option: OptionType, value: String) {

--- a/WhiskSwiftTools/Git.swift
+++ b/WhiskSwiftTools/Git.swift
@@ -32,7 +32,7 @@ class Git {
         request.httpMethod = "GET"
         
         group.enter()
-        let task = session.dataTask(with: request, completionHandler: { (data: Data?, response: URLResponse?, error: NSError?) -> Void in
+        let task = session.dataTask(with: request, completionHandler: { (data: Data?, response: URLResponse?, error: Error?) -> Void in
             if (error == nil) {
                 // Success
                 let statusCode = (response as! HTTPURLResponse).statusCode
@@ -65,7 +65,7 @@ class Git {
             }
             
             group.leave()
-        } as! (Data?, URLResponse?, Error?) -> Void)
+        }) //as! (Data?, URLResponse?, Error?) -> Void)
         task.resume()
     }
 }

--- a/WhiskSwiftTools/PBXProject.swift
+++ b/WhiskSwiftTools/PBXProject.swift
@@ -1,0 +1,102 @@
+//
+//  PBXProject.swift
+//  WhiskSwiftTools
+//
+//  Created by Paul Castro on 9/2/16.
+//  Copyright © 2016 IBM. All rights reserved.
+//
+
+import Foundation
+
+enum PBXParseState {
+    case inital
+    case inTarget
+    case inNamedTarget
+    case inSources
+    case inFiles
+    case parseFileNames
+    case done
+}
+
+class PBXProject {
+    
+    let fullPath: String!
+    let targetName: String!
+    var filesForTarget = [String:[String]]()
+    
+    init(file: String, targetName: String) {
+        self.fullPath = file+"/project.pbxproj"
+        self.targetName = targetName
+        parseFile()
+    }
+    
+    func parseFile() {
+        filesForTarget.removeAll()
+        
+        do {
+            let fileStr = try String(contentsOfFile: fullPath)
+            let scanner = Scanner(string: fileStr)
+            var line: NSString?
+            var targetKey: String?
+            
+            var parseState = PBXParseState.inital
+            while scanner.scanUpToCharacters(from: CharacterSet.newlines, into: &line) {
+                
+                guard let line = line else {
+                    print("PBXParse: Error, line from parseFile is nil, aborting.")
+                    return
+                }
+                var trimmedLine = line.trimmingCharacters(in: CharacterSet.whitespaces)
+                
+                switch parseState {
+                case .inital:
+                    if trimmedLine.range(of: "/* Begin PBXNativeTarget section */") != nil {
+                        parseState = .inTarget
+                        
+                    }
+                case .inTarget:
+                    if trimmedLine.range(of: "PBXNativeTarget \"\(targetName!)\" */;") != nil {
+                        parseState = .inNamedTarget
+                    }
+                case .inNamedTarget:
+                    if trimmedLine.range(of: "/* Sources */") != nil {
+                        parseState = .inSources
+                        let components = trimmedLine.components(separatedBy: CharacterSet.whitespaces)
+                        targetKey = components[0]
+                    }
+
+                case .inSources:
+                    let token = "\(targetKey!) /* Sources */"
+                    if trimmedLine.range(of: token ) != nil {
+                        parseState = .inFiles
+                    }
+                case .inFiles:
+                    if trimmedLine.range(of: "files = (") != nil {
+                        parseState = .parseFileNames
+                    }
+                case .parseFileNames:
+                    if (trimmedLine.range(of: "in Sources */") != nil) {
+                        let components = trimmedLine.components(separatedBy: CharacterSet.whitespaces)
+                        let fileName = components[2]                        
+                        if var files = filesForTarget[targetName] {
+                            files.append(fileName)
+                            filesForTarget[targetName] = files
+                        } else {
+                            var files = [String]()
+                            files.append(fileName)
+                            filesForTarget[targetName] = files
+                        }
+                    } else if (trimmedLine.range(of: ");") != nil) {
+                        parseState = .done
+                    }
+                case .done:
+                    return
+                }
+            }
+            
+        } catch {
+            print("Error parsing file \(error)")
+        }
+    }
+    
+}

--- a/WhiskSwiftTools/ProjectManager.swift
+++ b/WhiskSwiftTools/ProjectManager.swift
@@ -49,7 +49,7 @@ open class ProjectManager {
                 do {
                     self.projectReader?.clearAll()
                     
-                    if self.projectReader?.detectXcode(self.path) == false {
+                    if self.projectReader?.detectXcode(self.path).isXcode == false {
                         try self.projectReader?.readRootDependencies(true)
                     }
                     
@@ -95,7 +95,7 @@ open class ProjectManager {
                 do {
                     self.projectReader?.clearAll()
                     
-                    if self.projectReader?.detectXcode(self.path) == false {
+                    if self.projectReader?.detectXcode(self.path).isXcode == false {
                         try self.projectReader?.readRootDependencies(false)
                     }
                     try self.projectReader?.readProjectDirectory()

--- a/WhiskSwiftTools/ProjectReader.swift
+++ b/WhiskSwiftTools/ProjectReader.swift
@@ -246,25 +246,25 @@ open class ProjectReader {
         }
     }
     
-    open func detectXcode(_ path: String) -> Bool {
+    open func detectXcode(_ path: String) -> (isXcode: Bool, projectName: NSString?) {
         let fileManager = FileManager.default
         if let enumerator: FileManager.DirectoryEnumerator = fileManager.enumerator(atPath: path) {
             while let item = enumerator.nextObject() as? NSString {
                 if item.pathComponents.count == 1 {
                     if item.pathExtension == "xcodeproj" {
-                        return true
+                        return (isXcode: true, projectName: "\(path)/\(item)" as NSString)
                     }
                 }
             }
         }
-        return false
+        return (isXcode: false, projectName: nil)
     }
     
     open func readDirectory(_ dirPath: String, isDependency: Bool) throws {
         
         let isXcode = detectXcode(dirPath)
         
-        if isXcode == false {
+        if isXcode.isXcode == false {
             let dir: FileManager = FileManager.default
             
             if let enumerator: FileManager.DirectoryEnumerator = dir.enumerator(atPath: dirPath) {
@@ -329,7 +329,9 @@ open class ProjectReader {
                 try self.processManifestFiles(self.manifestDict)
             }
         } else {
-            let xcodeProject = WhiskTokenizer(from: dirPath, to:projectPath)
+            
+            print("Found xcode directory \(isXcode.projectName!)" )
+            let xcodeProject = WhiskTokenizer(from: dirPath, to:projectPath, projectFile: isXcode.projectName!)
             
             do {
                 let xcodeTuple = try xcodeProject.readXCodeProjectDirectory()

--- a/WhiskSwiftTools/WhiskInstaller.swift
+++ b/WhiskSwiftTools/WhiskInstaller.swift
@@ -64,6 +64,8 @@ class WhiskInstaller {
             } catch {
                 print("Error installing OpenWhisk project \(error)")
             }
+        case .Version:
+            ConsoleIO.printVersion()
         case .Help:
             ConsoleIO.printUsage()
         case .Undefined:


### PR DESCRIPTION
This code adds a new "target" field so when wsktool inspects an Xcode project, it will only process files that are part of the "target".  This allows developers to restrict OpenWhisk code to a target dedicated for actions and stops the tool from wasting time on irrelevant files.  Also, should help make parsing easier since we don't have to worry about WhiskKit being used in aforementioned irrelevant files.
