### PR TITLE
Remove deprecated swift 2 as a runtime

### DIFF
--- a/wsktools/WhiskSwiftTools.xcodeproj/project.xcworkspace/xcshareddata/WhiskSwiftTools.xcscmblueprint
+++ b/wsktools/WhiskSwiftTools.xcodeproj/project.xcworkspace/xcshareddata/WhiskSwiftTools.xcscmblueprint
@@ -9,20 +9,20 @@
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "06E1D60A-07E3-45BC-8101-A3D050C33727",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "65E71B0513DBFB09F39CEEF3A8B769CB93E66994" : "ZipArchive\/",
-    "E9057848A6186DD9CAE5574816428252CA2E16CD" : "WhiskSwiftTools\/"
+    "65E71B0513DBFB09F39CEEF3A8B769CB93E66994" : "openwhisk-xcode\/ZipArchive\/",
+    "E9057848A6186DD9CAE5574816428252CA2E16CD" : "openwhisk-xcode\/"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "WhiskSwiftTools",
   "DVTSourceControlWorkspaceBlueprintVersion" : 204,
-  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "WhiskSwiftTools.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "wsktools\/WhiskSwiftTools.xcodeproj",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
     {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/ZipArchive\/ZipArchive",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/ZipArchive\/ZipArchive.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "65E71B0513DBFB09F39CEEF3A8B769CB93E66994"
     },
     {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:paulcastro\/WhiskSwiftTools.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:openwhisk\/openwhisk-xcode.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "E9057848A6186DD9CAE5574816428252CA2E16CD"
     }

--- a/wsktools/WhiskSwiftTools/Git.swift
+++ b/wsktools/WhiskSwiftTools/Git.swift
@@ -61,7 +61,7 @@ class Git {
                 }
             } else {
                 // Failure
-                print("Failure cloning \(repo): %@", error?.localizedDescription);
+                print("Failure cloning \(repo): %@", error?.localizedDescription ?? "unknown error");
             }
             
             group.leave()

--- a/wsktools/WhiskSwiftTools/ProjectManager.swift
+++ b/wsktools/WhiskSwiftTools/ProjectManager.swift
@@ -326,8 +326,6 @@ open class ProjectManager {
             
             var runtimeStr = "nodejs"
             switch runtime {
-            case Runtime.swift:
-                runtimeStr = "swift"
             case Runtime.swift3:
                 runtimeStr = "swift:3"
             case Runtime.python:

--- a/wsktools/WhiskSwiftTools/ProjectReader.swift
+++ b/wsktools/WhiskSwiftTools/ProjectReader.swift
@@ -34,7 +34,6 @@ public enum WhiskProjectError: Error {
 }
 
 enum Runtime {
-    case swift
     case swift3
     case nodeJS
     case java
@@ -296,7 +295,7 @@ open class ProjectReader {
                                 }
                                 
                             }  else if item.hasSuffix(".swift") {
-                                try addAction(fullPath as NSString, item: item, runtime: .swift)
+                                try addAction(fullPath as NSString, item: item, runtime: .swift3)
                             }  else if item.hasSuffix(".js") {
                                 try addAction(fullPath as NSString, item: item, runtime: .nodeJS)
                             } else if item.hasSuffix(".json") {
@@ -499,7 +498,7 @@ open class ProjectReader {
                     if let item = actionsDict[(prefix+itemName) as NSString] {
                         var runtime = item.runtime
                         if let kind = action["kind"] as? String {
-                            if runtime == Runtime.swift && kind == "swift:3" {
+                            if runtime == Runtime.swift3 && kind == "swift:3" {
                                 runtime = Runtime.swift3
                             }
                         }

--- a/wsktools/WhiskSwiftTools/WhiskTokenizer.swift
+++ b/wsktools/WhiskSwiftTools/WhiskTokenizer.swift
@@ -120,7 +120,7 @@ open class WhiskTokenizer {
                                                 let fileUrl = URL(fileURLWithPath: actionPath)
                                                 try action.actionCode.write(to: fileUrl, atomically: false, encoding: String.Encoding.utf8)
                                                 
-                                                let whiskAction = Action(name: action.actionName as NSString, path: actionPath as NSString, runtime: Runtime.swift, parameters: nil)
+                                                let whiskAction = Action(name: action.actionName as NSString, path: actionPath as NSString, runtime: Runtime.swift3, parameters: nil)
                                                 
                                                 whiskActionArray.append(whiskAction)
                                                 


### PR DESCRIPTION
This PR makes swift:3 the default kind for wsktool, removes references to swift 2 runtime.