### PR TITLE
Use swift:default as kind

### DIFF
--- a/wsktools/WhiskSwiftTools/ProjectManager.swift
+++ b/wsktools/WhiskSwiftTools/ProjectManager.swift
@@ -326,8 +326,8 @@ open class ProjectManager {
             
             var runtimeStr = "nodejs"
             switch runtime {
-            case Runtime.swift3:
-                runtimeStr = "swift:3"
+            case Runtime.swift:
+                runtimeStr = "swift:default"
             case Runtime.python:
                 runtimeStr = "python"
             case Runtime.java:

--- a/wsktools/WhiskSwiftTools/ProjectReader.swift
+++ b/wsktools/WhiskSwiftTools/ProjectReader.swift
@@ -34,7 +34,7 @@ public enum WhiskProjectError: Error {
 }
 
 enum Runtime {
-    case swift3
+    case swift
     case nodeJS
     case java
     case python
@@ -295,7 +295,7 @@ open class ProjectReader {
                                 }
                                 
                             }  else if item.hasSuffix(".swift") {
-                                try addAction(fullPath as NSString, item: item, runtime: .swift3)
+                                try addAction(fullPath as NSString, item: item, runtime: .swift)
                             }  else if item.hasSuffix(".js") {
                                 try addAction(fullPath as NSString, item: item, runtime: .nodeJS)
                             } else if item.hasSuffix(".json") {
@@ -498,8 +498,9 @@ open class ProjectReader {
                     if let item = actionsDict[(prefix+itemName) as NSString] {
                         var runtime = item.runtime
                         if let kind = action["kind"] as? String {
-                            if runtime == Runtime.swift3 && kind == "swift:3" {
-                                runtime = Runtime.swift3
+                            // swift:default == swift:3 at the moment
+                            if runtime == Runtime.swift && kind == "swift:3" {
+                                runtime = Runtime.swift
                             }
                         }
                         

--- a/wsktools/WhiskSwiftTools/WhiskTokenizer.swift
+++ b/wsktools/WhiskSwiftTools/WhiskTokenizer.swift
@@ -120,7 +120,7 @@ open class WhiskTokenizer {
                                                 let fileUrl = URL(fileURLWithPath: actionPath)
                                                 try action.actionCode.write(to: fileUrl, atomically: false, encoding: String.Encoding.utf8)
                                                 
-                                                let whiskAction = Action(name: action.actionName as NSString, path: actionPath as NSString, runtime: Runtime.swift3, parameters: nil)
+                                                let whiskAction = Action(name: action.actionName as NSString, path: actionPath as NSString, runtime: Runtime.swift, parameters: nil)
                                                 
                                                 whiskActionArray.append(whiskAction)
                                                 


### PR DESCRIPTION
Fixes issue #21.  Use swift:default when processing a .swift file for wsktool.  