### PR TITLE
Add version number to ZipArchive in README

### DIFF
--- a/wsktools/README.md
+++ b/wsktools/README.md
@@ -45,7 +45,7 @@ A Swift 3 set of protocols and classes that lets you implement actions in Xcode.
 ## Building
 This code is build using Xcode 8.2.  
 
-There is a dependency on an ObjC project [ZipArchive](https://github.com/ZipArchive/ZipArchive).  OS X CLI targets and frameworks don't play together very well. The "easiest" way to reference it is to add the code manually to WhiskSwiftTools.  Clone ZipArchive and install per the documentations on the ZipArchive readme. Copy the SSZipArchive folder into the project folder and link to the `libz` library. WhiskSwiftTools includes bridging header file you can reference.
+There is a dependency on an ObjC project [ZipArchive version 1.7](https://github.com/ZipArchive/ZipArchive).  OS X CLI targets and frameworks don't play together very well. The "easiest" way to reference it is to add the code manually to WhiskSwiftTools.  Clone ZipArchive and install per the documentations on the ZipArchive readme. Copy the SSZipArchive folder into the project folder and link to the `libz` library. WhiskSwiftTools includes bridging header file you can reference.
 
 ## Using
 


### PR DESCRIPTION
wsktool will only build with ZipArchive 1.7.  This should be noted in the README for people testing out this code.